### PR TITLE
test nulling this optional variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "throughput_mode" {
 variable "mount_target_ip_address" {
   type        = string
   description = "The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target"
-  default     = ""
+  default     = null
 }
 
 variable "dns_name" {


### PR DESCRIPTION
All of a sudden we are getting errors in Terraform about an empty ip_address variable. Testing a version of the module that sets the default value of that variable to `null`.

From Terraform's [Expressions docs](https://www.terraform.io/docs/configuration/expressions.html#types-and-values): 
```
Finally, there is one special value that has no type:

null: a value that represents absence or omission. If you set an argument of a resource or
module to null, Terraform behaves as though you had completely omitted it — it will use the
argument's default value if it has one, or raise an error if the argument is mandatory. null is most
useful in conditional expressions, so you can dynamically omit an argument if a condition isn't
met.
```